### PR TITLE
expanded and documented GDB pretty-printer

### DIFF
--- a/doc/bloom/acknowledgements.adoc
+++ b/doc/bloom/acknowledgements.adoc
@@ -5,7 +5,8 @@
 
 Peter Dimov and Christian Mazakas reviewed significant portions of the code
 and documentation during the development phase. Sam Darwin provided support
-for CI setup and documentation building.
+for CI setup and documentation building. Braden Ganetsky contributed the
+GDB pretty-printer for `boost::bloom::filter`.
 
 The Boost acceptance review took place between the 13th and 22nd of May,
 2025. Big thanks to Arnaud Becheler for his expert managing. The

--- a/doc/bloom/tutorial.adoc
+++ b/doc/bloom/tutorial.adoc
@@ -303,3 +303,47 @@ to your project to allow for user-friendly inspection of `boost::bloom::filter`+
 
 image::natvis.png[align=center, title="View of a `boost::bloom::filter` with `boost_bloom.natvis`."]
 
+=== GDB Pretty-Printer
+
+`boost::bloom::filter` comes with a dedicated
+https://sourceware.org/gdb/current/onlinedocs/gdb.html/Pretty-Printing.html#Pretty-Printing[pretty-printer^]
+for visual inspection when debugging with GDB:
+
+[source,plaintext]
+-----
+(gdb) print f
+$1 = boost::bloom::filter with {capacity = 2000, data = 0x6da840, size = 250} = {[0] = 0 '\000',
+  [1] = 0 '\000', [2] = 0 '\000', [3] = 0 '\000', [4] = 0 '\000', [5] = 1 '\001'...}
+
+(gdb) # boost::bloom::filter does not have an operator[]. The following expression
+(gdb) # is used in place of print f.array()[30]
+(gdb) print f[30]
+$2 = 128 '\200'
+-----
+
+Remember to enable pretty-printing in GDB (typically a one-time setup):
+
+[source,plaintext]
+-----
+(gdb) set print pretty on
+-----
+
+The pretty-printer is automatically embedded in the program if your compiled binary
+format is ELF and the macro `BOOST_ALL_NO_EMBEDDED_GDB_SCRIPTS` is _not_ defined;
+embedded pretty-printers are enabled for a particular GDB session
+with this command (or by default by adding it to your `.gdbinit` configuration
+file):
+
+[source,plaintext,subs="+quotes"]
+-----
+(gdb) add-auto-load-safe-path _<path-to-executable>_
+-----
+
+Alternatively to the use of the embedded pretty-printer, you can explicitly
+load the link:../../extra/boost_bloom_printers.py[`boost_bloom_printers.py`^]
+script:
+
+[source,plaintext,subs="+quotes"]
+-----
+(gdb) source _<path-to-boost>_/libs/bloom/extra/boost_bloom_printers.py
+-----

--- a/extra/boost_bloom_printers.py
+++ b/extra/boost_bloom_printers.py
@@ -52,10 +52,10 @@ gdb.printing.register_pretty_printer(gdb.current_objfile(), boost_bloom_build_pr
 class BoostBloomFilterSubscriptMethod(gdb.xmethod.XMethod):
     def __init__(self):
         gdb.xmethod.XMethod.__init__(self, 'subscript')
- 
+
     def get_worker(self, method_name):
         if method_name == 'operator[]':
-            return BoostBloomFilterSubscriptWorker()    
+            return BoostBloomFilterSubscriptWorker()
 
 class BoostBloomFilterSubscriptWorker(gdb.xmethod.XMethodWorker):
     def get_arg_types(self):
@@ -63,14 +63,14 @@ class BoostBloomFilterSubscriptWorker(gdb.xmethod.XMethodWorker):
 
     def get_result_type(self, obj):
         return gdb.lookup_type('unsigned char')
- 
+
     def __call__(self, obj, index):
         fp = BoostBloomFilterPrinter(obj)
         if fp.array_size == 0:
-            print('Filter is null')
+            print('Error: Filter is null')
             return
         elif index < 0 or index >= fp.array_size:
-            print('Out of bounds')
+            print('Error: Out of bounds')
             return
         else:
             data = fp.data
@@ -80,7 +80,7 @@ class BoostBloomFilterMatcher(gdb.xmethod.XMethodMatcher):
     def __init__(self):
         gdb.xmethod.XMethodMatcher.__init__(self, 'BoostBloomFilterMatcher')
         self.methods = [BoostBloomFilterSubscriptMethod()]
- 
+
     def match(self, class_type, method_name):
         if not class_type.tag.startswith('boost::bloom::filter<'):
             return None
@@ -90,7 +90,7 @@ class BoostBloomFilterMatcher(gdb.xmethod.XMethodMatcher):
             if method.enabled:
                 worker = method.get_worker(method_name)
                 if worker:
-                    workers.append(worker) 
+                    workers.append(worker)
         return workers
 
 gdb.xmethod.register_xmethod_matcher(None, BoostBloomFilterMatcher())

--- a/extra/boost_bloom_printers.py
+++ b/extra/boost_bloom_printers.py
@@ -3,6 +3,7 @@
 # https://www.boost.org/LICENSE_1_0.txt
 
 import gdb.printing
+import gdb.xmethod
 
 class BoostBloomFilterPrinter:
     def __init__(self, val):
@@ -46,3 +47,50 @@ def boost_bloom_build_pretty_printer():
     return pp
 
 gdb.printing.register_pretty_printer(gdb.current_objfile(), boost_bloom_build_pretty_printer())
+
+# https://sourceware.org/gdb/current/onlinedocs/gdb.html/Writing-an-Xmethod.html
+class BoostBloomFilterSubscriptMethod(gdb.xmethod.XMethod):
+    def __init__(self):
+        gdb.xmethod.XMethod.__init__(self, 'subscript')
+ 
+    def get_worker(self, method_name):
+        if method_name == 'operator[]':
+            return BoostBloomFilterSubscriptWorker()    
+
+class BoostBloomFilterSubscriptWorker(gdb.xmethod.XMethodWorker):
+    def get_arg_types(self):
+        return [gdb.lookup_type('std::size_t')]
+
+    def get_result_type(self, obj):
+        return gdb.lookup_type('unsigned char')
+ 
+    def __call__(self, obj, index):
+        fp = BoostBloomFilterPrinter(obj)
+        if fp.array_size == 0:
+            print('Filter is null')
+            return
+        elif index < 0 or index >= fp.array_size:
+            print('Out of bounds')
+            return
+        else:
+            data = fp.data
+            return (data + index).dereference()
+
+class BoostBloomFilterMatcher(gdb.xmethod.XMethodMatcher):
+    def __init__(self):
+        gdb.xmethod.XMethodMatcher.__init__(self, 'BoostBloomFilterMatcher')
+        self.methods = [BoostBloomFilterSubscriptMethod()]
+ 
+    def match(self, class_type, method_name):
+        if not class_type.tag.startswith('boost::bloom::filter<'):
+            return None
+
+        workers = []
+        for method in self.methods:
+            if method.enabled:
+                worker = method.get_worker(method_name)
+                if worker:
+                    workers.append(worker) 
+        return workers
+
+gdb.xmethod.register_xmethod_matcher(None, BoostBloomFilterMatcher())

--- a/include/boost/bloom/detail/bloom_printers.hpp
+++ b/include/boost/bloom/detail/bloom_printers.hpp
@@ -2,7 +2,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
-// Generated on 2025-06-25T14:45:13
+// Generated on 2025-06-29T10:15:10
 
 #ifndef BOOST_BLOOM_DETAIL_BLOOM_PRINTERS_HPP
 #define BOOST_BLOOM_DETAIL_BLOOM_PRINTERS_HPP
@@ -16,6 +16,7 @@
 __asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
         ".ascii \"\\4gdb.inlined-script.BOOST_BLOOM_DETAIL_BLOOM_PRINTERS_HPP\\n\"\n"
         ".ascii \"import gdb.printing\\n\"\n"
+        ".ascii \"import gdb.xmethod\\n\"\n"
 
         ".ascii \"class BoostBloomFilterPrinter:\\n\"\n"
         ".ascii \"    def __init__(self, val):\\n\"\n"
@@ -59,6 +60,53 @@ __asm__(".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
         ".ascii \"    return pp\\n\"\n"
 
         ".ascii \"gdb.printing.register_pretty_printer(gdb.current_objfile(), boost_bloom_build_pretty_printer())\\n\"\n"
+
+        ".ascii \"# https://sourceware.org/gdb/current/onlinedocs/gdb.html/Writing-an-Xmethod.html\\n\"\n"
+        ".ascii \"class BoostBloomFilterSubscriptMethod(gdb.xmethod.XMethod):\\n\"\n"
+        ".ascii \"    def __init__(self):\\n\"\n"
+        ".ascii \"        gdb.xmethod.XMethod.__init__(self, 'subscript')\\n\"\n"
+
+        ".ascii \"    def get_worker(self, method_name):\\n\"\n"
+        ".ascii \"        if method_name == 'operator[]':\\n\"\n"
+        ".ascii \"            return BoostBloomFilterSubscriptWorker()\\n\"\n"
+
+        ".ascii \"class BoostBloomFilterSubscriptWorker(gdb.xmethod.XMethodWorker):\\n\"\n"
+        ".ascii \"    def get_arg_types(self):\\n\"\n"
+        ".ascii \"        return [gdb.lookup_type('std::size_t')]\\n\"\n"
+
+        ".ascii \"    def get_result_type(self, obj):\\n\"\n"
+        ".ascii \"        return gdb.lookup_type('unsigned char')\\n\"\n"
+
+        ".ascii \"    def __call__(self, obj, index):\\n\"\n"
+        ".ascii \"        fp = BoostBloomFilterPrinter(obj)\\n\"\n"
+        ".ascii \"        if fp.array_size == 0:\\n\"\n"
+        ".ascii \"            print('Error: Filter is null')\\n\"\n"
+        ".ascii \"            return\\n\"\n"
+        ".ascii \"        elif index < 0 or index >= fp.array_size:\\n\"\n"
+        ".ascii \"            print('Error: Out of bounds')\\n\"\n"
+        ".ascii \"            return\\n\"\n"
+        ".ascii \"        else:\\n\"\n"
+        ".ascii \"            data = fp.data\\n\"\n"
+        ".ascii \"            return (data + index).dereference()\\n\"\n"
+
+        ".ascii \"class BoostBloomFilterMatcher(gdb.xmethod.XMethodMatcher):\\n\"\n"
+        ".ascii \"    def __init__(self):\\n\"\n"
+        ".ascii \"        gdb.xmethod.XMethodMatcher.__init__(self, 'BoostBloomFilterMatcher')\\n\"\n"
+        ".ascii \"        self.methods = [BoostBloomFilterSubscriptMethod()]\\n\"\n"
+
+        ".ascii \"    def match(self, class_type, method_name):\\n\"\n"
+        ".ascii \"        if not class_type.tag.startswith('boost::bloom::filter<'):\\n\"\n"
+        ".ascii \"            return None\\n\"\n"
+
+        ".ascii \"        workers = []\\n\"\n"
+        ".ascii \"        for method in self.methods:\\n\"\n"
+        ".ascii \"            if method.enabled:\\n\"\n"
+        ".ascii \"                worker = method.get_worker(method_name)\\n\"\n"
+        ".ascii \"                if worker:\\n\"\n"
+        ".ascii \"                    workers.append(worker)\\n\"\n"
+        ".ascii \"        return workers\\n\"\n"
+
+        ".ascii \"gdb.xmethod.register_xmethod_matcher(None, BoostBloomFilterMatcher())\\n\"\n"
 
         ".byte 0\n"
         ".popsection\n");

--- a/test/test_visualization.cpp
+++ b/test/test_visualization.cpp
@@ -25,7 +25,7 @@ int main()
 {
   boost::bloom::filter<int, 1> filter1{};
   boost::bloom::filter<int, 1> filter2{1};
-  boost::bloom::filter<int, 1024> filter3{{1,2,3,4,5}, 512};
+  boost::bloom::filter<int, 5> filter3{{1,2,3,4,5}, 2000};
 
   use(filter1);
   use(filter2);


### PR DESCRIPTION
@k3DW playing locally with the pretty-printer, I've realized that the array display is of little use because it's limited by GDB to a few elements and these filters are generally very large (hundreds of thousands or millions of bytes). To remedy this, I've implemented a custom `operator[]` Xmethod used like this:

https://38.bloom.prtest3.cppalliance.org/libs/bloom/doc/html/index.html#tutorial_gdb_pretty_printer

Please review thoroughly as I'm not an expert in this area. Also, you may have ideas about better interfaces than this one. If/when eveything's correct could you please update `bloom_printers.hpp` accordingly in this same branch? Thank you!